### PR TITLE
main.ratt.pl: initialize ref_shift hash ref prior to use (closes #5)

### DIFF
--- a/main.ratt.pl
+++ b/main.ratt.pl
@@ -229,7 +229,7 @@ elsif ($ARGV[0] eq "Transfer") {
   map {
 	if (/(\S+)\.embl$/){
 	  my $refName=$1;
-	  my $ref_shift;
+	  my $ref_shift = {};
 	  print "working on $refName\n";
 	  
 	  # fill the shift hash with the coords 


### PR DESCRIPTION
The variable is defined as a scalar and used as a hash reference, which
triggers a perl warning (error?):

  Can't use an undefined value as an ARRAY reference at /<path>/ratt/main.ratt.pl line 244.

and causes the transfer step to fail.